### PR TITLE
Fix issue with scripts inside Svelte tags

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -28,6 +28,9 @@ class TagContent {
   }
 
   public toTag() {
+    if (this.contents.length === 0) {
+      return "";
+    }
     return `${
       this.startTag ||
       `<${this.tagName}${this.defaultAttrs ? ` ${this.defaultAttrs}` : ""}>`
@@ -57,15 +60,7 @@ function parseHtml(html: string) {
   const moduleContext = new TagContent("script", 'context="module"');
   const instanceScript = new TagContent("script");
   const svelteTags: TagContent[] = [];
-  let newHtml = html.replace(SCRIPTS_RE, (_, startTag, script: string) => {
-    let scriptContent = instanceScript;
-    if (IS_MODULE_CONTEXT_RE.test(startTag)) {
-      scriptContent = moduleContext;
-    }
-    scriptContent.addTag(startTag, script);
-    return "";
-  });
-  newHtml = newHtml.replace(SVELTE_TAGS_RE, (_, startTag, inner) => {
+  let newHtml = html.replace(SVELTE_TAGS_RE, (_, startTag, inner) => {
     const tagName = GET_SVELTE_TAG_NAME_RE.exec(
       startTag.slice(1),
     )![0].toLowerCase();
@@ -77,6 +72,15 @@ function parseHtml(html: string) {
     svelteTag.addTag(startTag, inner);
     return "";
   });
+  newHtml = newHtml.replace(SCRIPTS_RE, (_, startTag, script: string) => {
+    let scriptContent = instanceScript;
+    if (IS_MODULE_CONTEXT_RE.test(startTag)) {
+      scriptContent = moduleContext;
+    }
+    scriptContent.addTag(startTag, script);
+    return "";
+  });
+  
   return { html: newHtml, moduleContext, instanceScript, svelteTags };
 }
 

--- a/tests/__snapshots__/transform-with-head.test.ts.snap
+++ b/tests/__snapshots__/transform-with-head.test.ts.snap
@@ -4,9 +4,7 @@ exports[`transform with head basic 1`] = `
 "<script context=\\"module\\">
 export const frontmatter = {\\"title\\":\\"Hey\\"}
 </script>
-<script>
 
-</script>
 <svelte:head>
 <title>Hey</title>
 <meta property=\\"og:title\\" content=\\"Hey\\">

--- a/tests/__snapshots__/transform-with-highlight.test.ts.snap
+++ b/tests/__snapshots__/transform-with-highlight.test.ts.snap
@@ -4,9 +4,7 @@ exports[`transform with highlight highlight 1`] = `
 "<script context=\\"module\\">
 export const frontmatter = {\\"title\\":\\"Hey\\"}
 </script>
-<script>
 
-</script>
 <svelte:head>
 <title>Hey</title>
 <meta property=\\"og:title\\" content=\\"Hey\\">
@@ -28,9 +26,7 @@ exports[`transform with highlight highlight svelte 1`] = `
 "<script context=\\"module\\">
 export const frontmatter = {\\"title\\":\\"Hello Svelte\\"}
 </script>
-<script>
 
-</script>
 <svelte:head>
 <title>Hello Svelte</title>
 <meta property=\\"og:title\\" content=\\"Hello Svelte\\">
@@ -63,9 +59,7 @@ exports[`transform with highlight highlight svelte with line numbers 1`] = `
 "<script context=\\"module\\">
 export const frontmatter = {\\"title\\":\\"Hello Svelte\\"}
 </script>
-<script>
 
-</script>
 <svelte:head>
 <title>Hello Svelte</title>
 <meta property=\\"og:title\\" content=\\"Hello Svelte\\">
@@ -101,9 +95,7 @@ exports[`transform with highlight highlight with fixtures no-dupe-else-if-blocks
 "<script context=\\"module\\">
 export const frontmatter = {\\"pageClass\\":\\"rule-details\\",\\"sidebarDepth\\":0,\\"title\\":\\"@ota-meshi/svelte/no-dupe-else-if-blocks\\",\\"description\\":\\"disallow duplicate conditions in \`{#if}\` / \`{:else if}\` chains\\",\\"since\\":\\"v0.0.1\\"}
 </script>
-<script>
 
-</script>
 <svelte:head>
 <title>@ota-meshi/svelte/no-dupe-else-if-blocks</title>
 <meta property=\\"og:title\\" content=\\"@ota-meshi/svelte/no-dupe-else-if-blocks\\">

--- a/tests/__snapshots__/transform.test.ts.snap
+++ b/tests/__snapshots__/transform.test.ts.snap
@@ -4,9 +4,7 @@ exports[`transform basic 1`] = `
 "<script context=\\"module\\">
 export const frontmatter = {\\"title\\":\\"Hey\\"}
 </script>
-<script>
 
-</script>
 <svelte:head>
 <title>Hey</title>
 <meta property=\\"og:title\\" content=\\"Hey\\">
@@ -24,9 +22,7 @@ exports[`transform escape curly braces in code block 1`] = `
 "<script context=\\"module\\">
 export const frontmatter = {}
 </script>
-<script>
 
-</script>
 
 <div class=\\"markdown-body\\"><pre><code>function test() &#123;
     return foo
@@ -39,9 +35,7 @@ exports[`transform escape curly braces in code inline 1`] = `
 "<script context=\\"module\\">
 export const frontmatter = {}
 </script>
-<script>
 
-</script>
 
 <div class=\\"markdown-body\\"><p><code>&#123;...&#125;</code></p>
 </div>"
@@ -51,9 +45,7 @@ exports[`transform escape curly braces in fence 1`] = `
 "<script context=\\"module\\">
 export const frontmatter = {}
 </script>
-<script>
 
-</script>
 
 <div class=\\"markdown-body\\"><pre><code class=\\"language-js\\">function test() &#123;
  return foo
@@ -66,9 +58,7 @@ exports[`transform escape curly braces in header 1`] = `
 "<script context=\\"module\\">
 export const frontmatter = {\\"title\\":\\"\`{#if}\`\\"}
 </script>
-<script>
 
-</script>
 <svelte:head>
 <title>\`&#123;#if&#125;\`</title>
 <meta property=\\"og:title\\" content=\\"\`&#123;#if&#125;\`\\">
@@ -80,9 +70,7 @@ exports[`transform escapeCodeTagInterpolation 1`] = `
 "<script context=\\"module\\">
 export const frontmatter = {}
 </script>
-<script>
 
-</script>
 
 <div class=\\"markdown-body\\"><div>{hello}</div>
 <pre><code class=\\"language-svelte\\">&lt;div&gt;&#123;hello&#125;&lt;/div&gt;
@@ -94,9 +82,7 @@ exports[`transform exposes frontmatter 1`] = `
 "<script context=\\"module\\">
 export const frontmatter = {\\"title\\":\\"Hey\\"}
 </script>
-<script>
 
-</script>
 <svelte:head>
 <title>Hey</title>
 <meta property=\\"og:title\\" content=\\"Hey\\">
@@ -109,9 +95,7 @@ exports[`transform frontmatter interpolation 1`] = `
 "<script context=\\"module\\">
 export const frontmatter = {}
 </script>
-<script>
 
-</script>
 
 <div class=\\"markdown-body\\"><hr>
 <h2>name: ‘My Cool App’</h2>
@@ -134,13 +118,25 @@ import Foo from './Foo.vue'
 </div>"
 `;
 
+exports[`transform scriptInsideSvelte 1`] = `
+"<script context=\\"module\\">
+export const frontmatter = {}
+</script>
+
+<svelte:head>
+<script async src=\\"foo.js\\"></script>
+</svelte:head>
+<div class=\\"markdown-body\\"><p></p>
+<pre><code class=\\"language-svelte\\">&lt;svelte:head&gt;&lt;script async src=&quot;foo.js&quot;&gt;&lt;/script&gt;&lt;/svelte:head&gt;
+</code></pre>
+</div>"
+`;
+
 exports[`transform style 1`] = `
 "<script context=\\"module\\">
 export const frontmatter = {}
 </script>
-<script>
 
-</script>
 
 <div class=\\"markdown-body\\"><h1>Hello</h1>
 <style>h1 { color: red }</style></div>"

--- a/tests/fixtures/no-dupe-else-if-blocks.md.svelte
+++ b/tests/fixtures/no-dupe-else-if-blocks.md.svelte
@@ -1,9 +1,7 @@
 <script context="module">
 export const frontmatter = {"pageClass":"rule-details","sidebarDepth":0,"title":"@ota-meshi/svelte/no-dupe-else-if-blocks","description":"disallow duplicate conditions in `{#if}` / `{:else if}` chains","since":"v0.0.1"}
 </script>
-<script>
 
-</script>
 <svelte:head>
 <title>@ota-meshi/svelte/no-dupe-else-if-blocks</title>
 <meta property="og:title" content="@ota-meshi/svelte/no-dupe-else-if-blocks">

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -63,6 +63,17 @@ title: Hey
     chai.expect(mdToSvelte("", md)).toMatchSnapshot();
   });
 
+  it("scriptInsideSvelte", () => {
+    const md = `
+<svelte:head><script async src="foo.js"></script></svelte:head>
+
+\`\`\`svelte
+<svelte:head><script async src="foo.js"></script></svelte:head>
+\`\`\`
+`;
+    chai.expect(mdToSvelte("", md)).toMatchSnapshot();
+  });
+
   it("frontmatter interpolation", () => {
     const md = `
 ---


### PR DESCRIPTION
The current logic goes through the rendered HTML, and first extracts the script elements, then all the Svelte tags. This causes a problem when a Svelte tag contains a script element, which is not all that uncommon with, say, `<svelte:head>`. In this case, because scripts are processed first, and because this is a regular expression, these scripts are pulled out of the Svelte tags and into regular scripts. 

By changing the order and removing Svelte tags first, these scripts are no longer present to get pulled into the output directly.

In the process, this commit also adds a cut so that a script element is not rendered to a tag at all when it has no content. Sure, scripts in HTML may be driven by attributes alone, but here he logic is simply sorting scripts, and this stops empty scripts from being inserted into the output. The snapshots show the effect clearly. 