### PR TITLE
feat: parse Svelte components as HTML

### DIFF
--- a/.changeset/eleven-clouds-yawn.md
+++ b/.changeset/eleven-clouds-yawn.md
@@ -1,5 +1,5 @@
 ---
-"vite-plugin-svelte-md": patch
+"vite-plugin-svelte-md": minor
 ---
 
-In markdown, parse Svelte components as HTML block elements.
+Extend Markdown parsing to recognize Svelte components as HTML blocks and inline HTML tags.

--- a/.changeset/eleven-clouds-yawn.md
+++ b/.changeset/eleven-clouds-yawn.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-svelte-md": patch
+---
+
+Parse Svelte components as HTML.

--- a/.changeset/eleven-clouds-yawn.md
+++ b/.changeset/eleven-clouds-yawn.md
@@ -2,4 +2,4 @@
 "vite-plugin-svelte-md": patch
 ---
 
-Parse Svelte components as HTML.
+In markdown, parse Svelte components as HTML block elements.

--- a/README.md
+++ b/README.md
@@ -281,8 +281,17 @@ mdSvelte({
         `{@html ${JSON.stringify(katex.renderToString(content, { displayMode }))}}`,
     }),
 });
-
 ```
+
+## 🥽 Markdown Compatibility
+
+`vite-plugin-svelte-md` is built on top of [markdown-exit](https://github.com/serkodev/markdown-exit), a TypeScript rewrite of [markdown-it](https://github.com/markdown-it/markdown-it), which announces 100% [CommonMark](https://commonmark.org/) compliance. However, for better compatibility with Svelte, HTML tag recognition has been extended to support Svelte components. In practice, it means that we interpret the [CommonMark HTML blocks specification](https://spec.commonmark.org/0.30/#html-blocks) item 6 as follows:
+
+6. Start condition: line begins the string `<` or `</` followed by one of the strings (case-insensitive) `address`, ..., `ul` **or a valid Svelte component name** followed by a space, a tab, the end of the line, the string `>`, or the string `/>`.
+
+Inline HTML parsing is also extended to support Svelte components, so that you can use them in the middle of a paragraph.
+
+Please [open an issue](https://github.com/ota-meshi/vite-plugin-svelte-md/issues/new) if this Markdown extension causes issues with your content.
 
 ## :beers: Contributing
 

--- a/README.md
+++ b/README.md
@@ -285,11 +285,15 @@ mdSvelte({
 
 ## 🥽 Markdown Compatibility
 
-`vite-plugin-svelte-md` is built on top of [markdown-exit](https://github.com/serkodev/markdown-exit), a TypeScript rewrite of [markdown-it](https://github.com/markdown-it/markdown-it), which announces 100% [CommonMark](https://commonmark.org/) compliance. However, for better compatibility with Svelte, HTML tag recognition has been extended to support Svelte components. In practice, it means that we interpret the [CommonMark HTML blocks specification](https://spec.commonmark.org/0.30/#html-blocks) item 6 as follows:
+`vite-plugin-svelte-md` is built on top of [markdown-exit](https://github.com/serkodev/markdown-exit), a TypeScript rewrite of [markdown-it](https://github.com/markdown-it/markdown-it), which announces 100% [CommonMark](https://commonmark.org/) compliance. However, for better compatibility with Svelte, HTML tag recognition has been extended to support Svelte components. In practice, it means that we interpret the [CommonMark HTML blocks specification](https://spec.commonmark.org/0.31.2/#html-blocks) item 6 as follows:
 
-6. Start condition: line begins the string `<` or `</` followed by one of the strings (case-insensitive) `address`, ..., `ul` **or a valid Svelte component name** followed by a space, a tab, the end of the line, the string `>`, or the string `/>`.
+6. Start condition: line begins with the string `<` or `</` followed by one of the strings (case-insensitive) `address`, ..., `ul` **or a valid Svelte component name** followed by a space, a tab, the end of the line, the string `>`, or the string `/>`.
 
-Inline HTML parsing is also extended to support Svelte components, so that you can use them in the middle of a paragraph.
+Inline HTML parsing is also extended to support Svelte components, so that you can use them in the middle of a paragraph. The [CommonMark raw HTML specification](https://spec.commonmark.org/0.31.2/#raw-html) is interpreted as follows:
+
+- An HTML tag consists of an open tag, a closing tag, an HTML comment, a processing instruction, a declaration, a CDATA section, **an open Svelte component tag, or a closing Svelte component tag**.
+- An open Svelte component tag consists of a `<` character, followed by a valid Svelte component name,  optionally followed by whitespace and a string not containing `>`, followed by a `>` character or a `/>` string.
+- A closing Svelte component tag consists of a `</` character, followed by a valid Svelte component name, optionally followed by whitespace, followed by a `>` character.
 
 Please [open an issue](https://github.com/ota-meshi/vite-plugin-svelte-md/issues/new) if this Markdown extension causes issues with your content.
 

--- a/src/markdown-it-svelte-components/index.ts
+++ b/src/markdown-it-svelte-components/index.ts
@@ -2,10 +2,10 @@ import type { MarkdownExit } from "markdown-exit";
 
 // Adapted from https://github.com/sveltejs/svelte/blob/3dbd95075c324304d668d72e0c08ed958173fb8f/packages/svelte/src/compiler/phases/1-parse/state/element.js#L39-L42
 // and https://github.com/serkodev/markdown-exit/blob/fe1351070a5841426223ab4a0a5c7874ba2b1257/packages/markdown-exit/src/parser/block/rules/html_block.ts#L16
-const SVELTE_COMPONENT_BLOCK_RE =
+const SVELTE_BLOCK_RE =
   /^<\/?(?:\p{Lu}[\p{ID_Continue}$.\u200c\u200d]*|\p{ID_Start}[\p{ID_Continue}$\u200c\u200d]*(?:\.[\p{ID_Continue}$\u200c\u200d]+)+)(?=\s|\/?>|$)/u;
-const SVELTE_COMPONENT_INLINE_RE =
-  /^<\/?(?:\p{Lu}[\p{ID_Continue}$.\u200c\u200d]*|\p{ID_Start}[\p{ID_Continue}$\u200c\u200d]*(?:\.[\p{ID_Continue}$\u200c\u200d]+)+)(?:\s[^>]*|\/?)>/u;
+const SVELTE_INLINE_RE =
+  /^<(?:\p{Lu}[\p{ID_Continue}$.\u200c\u200d]*|\p{ID_Start}[\p{ID_Continue}$\u200c\u200d]*(?:\.[\p{ID_Continue}$\u200c\u200d]+)+)(?:\s[^>]*|\/?)>|^<\/(?:\p{Lu}[\p{ID_Continue}$.\u200c\u200d]*|\p{ID_Start}[\p{ID_Continue}$\u200c\u200d]*(?:\.[\p{ID_Continue}$\u200c\u200d]+)+)\s*>/u;
 
 /**
  * Markdown-exit plugin to extend the HTML CommonMark specification to recognize Svelte components as HTML tags, both for block and inline parsing.
@@ -14,9 +14,9 @@ export default function plugin(md: MarkdownExit): void {
   /**
    * Adapted from https://github.com/serkodev/markdown-exit/blob/fe1351070a5841426223ab4a0a5c7874ba2b1257/packages/markdown-exit/src/parser/block/rules/html_block.ts#L20-L77
    *
-   * Implement the following [CommonMark HTML blocks specification](https://spec.commonmark.org/0.30/#html-blocks) extension:
+   * Implement the following [CommonMark HTML blocks specification](https://spec.commonmark.org/0.31.2/#html-blocks) extension:
    *
-   * 6. Start condition: line begins the string `<` or `</` followed by one of the strings (case-insensitive) `address`, ..., `ul` **or a valid Svelte component name** followed by a space, a tab, the end of the line, the string `>`, or the string `/>`.
+   * 6. Start condition: line begins with the string `<` or `</` followed by one of the strings (case-insensitive) `address`, ..., `ul` **or a valid Svelte component name** followed by a space, a tab, the end of the line, the string `>`, or the string `/>`.
    *    End condition: line is followed by a blank line.
    *
    * The beginning of the rule is already implemented by the original `html_block` rule.
@@ -36,7 +36,7 @@ export default function plugin(md: MarkdownExit): void {
 
       // Check if the line starts with `<` or `</` followed by a valid Svelte component name
       // followed by a space, the end of the line, the string `>`, or the string `/>`
-      if (!SVELTE_COMPONENT_BLOCK_RE.test(lineText)) return false;
+      if (!SVELTE_BLOCK_RE.test(lineText)) return false;
 
       // Svelte components can close paragraphs, references and blockquotes
       if (silent) return true;
@@ -73,15 +73,21 @@ export default function plugin(md: MarkdownExit): void {
     { alt: ["paragraph", "reference", "blockquote"] },
   );
 
-  // Extend https://spec.commonmark.org/0.30/#tag-name for Svelte components
-  // Adapted from https://github.com/serkodev/markdown-exit/blob/fe1351070a5841426223ab4a0a5c7874ba2b1257/packages/markdown-exit/src/parser/inline/rules/html_inline.ts#L19-L55
+  /**
+   * Adapted from https://github.com/serkodev/markdown-exit/blob/fe1351070a5841426223ab4a0a5c7874ba2b1257/packages/markdown-exit/src/parser/inline/rules/html_inline.ts#L19-L55
+   *
+   * Implement the following [CommonMark raw HTML specification](https://spec.commonmark.org/0.31.2/#raw-html) extension:
+   *
+   * - An HTML tag consists of an open tag, a closing tag, an HTML comment, a processing instruction, a declaration, a CDATA section, **an open Svelte component tag, or a closing Svelte component tag**.
+   * - An open Svelte component tag consists of a `<` character, followed by a valid Svelte component name,  optionally followed by whitespace and a string not containing `>`, followed by a `>` character or a `/>` string.
+   * - A closing Svelte component tag consists of a `</` character, followed by a valid Svelte component name, optionally followed by whitespace, followed by a `>` character.
+   */
   md.inline.ruler.after("html_inline", "svelte_inline", (state, silent) => {
     if (!state.md.options.html) return false;
 
     const line = state.src.slice(state.pos, state.posMax);
 
-    // `<` or `</` followed by a valid Svelte component name until the next `>`
-    const match = SVELTE_COMPONENT_INLINE_RE.exec(line);
+    const match = SVELTE_INLINE_RE.exec(line);
 
     if (!match) return false;
 

--- a/src/markdown-it-svelte-components/index.ts
+++ b/src/markdown-it-svelte-components/index.ts
@@ -1,14 +1,19 @@
 import type { MarkdownExit } from "markdown-exit";
 
+// Adapted from
 // https://github.com/sveltejs/svelte/blob/3dbd95075c324304d668d72e0c08ed958173fb8f/packages/svelte/src/compiler/phases/1-parse/state/element.js#L39-L42
-const SVELTE_COMPONENT_RE =
-  /^<(?:\p{Lu}[\p{ID_Continue}$.\u200c\u200d]*|\p{ID_Start}[\p{ID_Continue}$\u200c\u200d]*(?:\.[\p{ID_Continue}$\u200c\u200d]+)+)/u;
+// and
+// https://github.com/serkodev/markdown-exit/blob/fe1351070a5841426223ab4a0a5c7874ba2b1257/packages/markdown-exit/src/parser/block/rules/html_block.ts#L16
+const SVELTE_COMPONENT_BLOCK_RE =
+  /^<\/?(?:\p{Lu}[\p{ID_Continue}$.\u200c\u200d]*|\p{ID_Start}[\p{ID_Continue}$\u200c\u200d]*(?:\.[\p{ID_Continue}$\u200c\u200d]+)+)(?=\s|\/?>|$)/u;
+const SVELTE_COMPONENT_INLINE_RE =
+  /^<\/?(?:\p{Lu}|\p{ID_Start}[\p{ID_Continue}$\u200c\u200d]*\.[\p{ID_Continue}$\u200c\u200d])[^>]+>/u;
 
 /**
  * Parse Svelte components as html_block and html_inline tokens
  */
 export default function plugin(md: MarkdownExit): void {
-  // Find lines starting with `<Something` and consider as HTML all lines until an ending `>` is found
+  // Find lines starting with `<Something` and apply the same logic as for https://spec.commonmark.org/0.30/#html-blocks, #6
   // Adapted from https://github.com/serkodev/markdown-exit/blob/fe1351070a5841426223ab4a0a5c7874ba2b1257/packages/markdown-exit/src/parser/block/rules/html_block.ts#L20-L77
   md.block.ruler.after(
     "html_block",
@@ -21,18 +26,18 @@ export default function plugin(md: MarkdownExit): void {
         state.eMarks[startLine],
       );
 
-      if (!SVELTE_COMPONENT_RE.test(lineText)) return false;
+      if (!SVELTE_COMPONENT_BLOCK_RE.test(lineText)) return false;
 
       // We found `<Something` starting a line, let's find a `>` that ends a line
-      let nextLine = startLine;
+      let nextLine = startLine + 1;
 
-      while (nextLine < endLine) {
+      while (nextLine < endLine && state.sCount[nextLine] >= state.blkIndent) {
         const nextLineText = state.src.slice(
           state.bMarks[nextLine] + state.tShift[nextLine],
           state.eMarks[nextLine],
         );
+        if (nextLineText === "") break;
         nextLine++; // Make `nextLine` always point to the next line
-        if (nextLineText.trimEnd().endsWith(">")) break;
       }
 
       // Update the line pointer
@@ -51,24 +56,19 @@ export default function plugin(md: MarkdownExit): void {
     },
   );
 
-  // Same logic as above, find `<Something` then `>` in inline text
+  // Implement https://spec.commonmark.org/0.30/#tag-name for Svelte components
   // Adapted from https://github.com/serkodev/markdown-exit/blob/fe1351070a5841426223ab4a0a5c7874ba2b1257/packages/markdown-exit/src/parser/inline/rules/html_inline.ts#L19-L55
   md.inline.ruler.after("html_inline", "svelte_tag_inline", (state) => {
     if (!state.md.options.html) return false;
 
     const line = state.src.slice(state.pos, state.posMax);
-    const match = SVELTE_COMPONENT_RE.exec(line);
+    const match = SVELTE_COMPONENT_INLINE_RE.exec(line);
 
     if (!match) return false;
 
-    const end = line.indexOf(">", match[0].length);
-
-    if (end === -1) return false;
-
-    state.pos += end + 1;
-
+    state.pos += match[0].length;
     const token = state.push("html_inline", "", 0);
-    token.content = line.slice(match.index, end + 1);
+    token.content = line.slice(0, match[0].length);
 
     return true;
   });

--- a/src/markdown-it-svelte-components/index.ts
+++ b/src/markdown-it-svelte-components/index.ts
@@ -8,6 +8,8 @@ const SVELTE_COMPONENT_RE =
  * Parse Svelte components as html_block and html_inline tokens
  */
 export default function plugin(md: MarkdownExit): void {
+  // Find lines starting with `<Something` and consider as HTML all lines until an ending `>` is found
+  // Adapted from https://github.com/serkodev/markdown-exit/blob/fe1351070a5841426223ab4a0a5c7874ba2b1257/packages/markdown-exit/src/parser/block/rules/html_block.ts#L20-L77
   md.block.ruler.after(
     "html_block",
     "svelte_tag",
@@ -50,6 +52,7 @@ export default function plugin(md: MarkdownExit): void {
   );
 
   // Same logic as above, find `<Something` then `>` in inline text
+  // Adapted from https://github.com/serkodev/markdown-exit/blob/fe1351070a5841426223ab4a0a5c7874ba2b1257/packages/markdown-exit/src/parser/inline/rules/html_inline.ts#L19-L55
   md.inline.ruler.after("html_inline", "svelte_tag_inline", (state) => {
     if (!state.md.options.html) return false;
 

--- a/src/markdown-it-svelte-components/index.ts
+++ b/src/markdown-it-svelte-components/index.ts
@@ -2,8 +2,7 @@ import type { MarkdownExit } from "markdown-exit";
 
 // Adapted from
 // https://github.com/sveltejs/svelte/blob/3dbd95075c324304d668d72e0c08ed958173fb8f/packages/svelte/src/compiler/phases/1-parse/state/element.js#L39-L42
-// and
-// https://github.com/serkodev/markdown-exit/blob/fe1351070a5841426223ab4a0a5c7874ba2b1257/packages/markdown-exit/src/parser/block/rules/html_block.ts#L16
+// and https://github.com/serkodev/markdown-exit/blob/fe1351070a5841426223ab4a0a5c7874ba2b1257/packages/markdown-exit/src/parser/block/rules/html_block.ts#L16
 const SVELTE_COMPONENT_BLOCK_RE =
   /^<\/?(?:\p{Lu}[\p{ID_Continue}$.\u200c\u200d]*|\p{ID_Start}[\p{ID_Continue}$\u200c\u200d]*(?:\.[\p{ID_Continue}$\u200c\u200d]+)+)(?=\s|\/?>|$)/u;
 const SVELTE_COMPONENT_INLINE_RE =

--- a/src/markdown-it-svelte-components/index.ts
+++ b/src/markdown-it-svelte-components/index.ts
@@ -24,7 +24,7 @@ export default function plugin(md: MarkdownExit): void {
   md.block.ruler.after(
     "html_block",
     "svelte_block",
-    (state, startLine, endLine) => {
+    (state, startLine, endLine, silent) => {
       // No need to run the rule if HTML is not enabled
       if (!state.md.options.html) return false;
 
@@ -37,6 +37,9 @@ export default function plugin(md: MarkdownExit): void {
       // Check if the line starts with `<` or `</` followed by a valid Svelte component name
       // followed by a space, the end of the line, the string `>`, or the string `/>`
       if (!SVELTE_COMPONENT_BLOCK_RE.test(lineText)) return false;
+
+      // Svelte components can close paragraphs, references and blockquotes
+      if (silent) return true;
 
       // "End condition: line is followed by a blank line."
       // Let's find the next blank line
@@ -67,11 +70,14 @@ export default function plugin(md: MarkdownExit): void {
 
       return true;
     },
+    // List of rules that can be interrupted by a Svelte component
+    // (the rule will be called with silent=true to see if the current block should be interrupted)
+    { alt: ["paragraph", "reference", "blockquote"] },
   );
 
   // Extend https://spec.commonmark.org/0.30/#tag-name for Svelte components
   // Adapted from https://github.com/serkodev/markdown-exit/blob/fe1351070a5841426223ab4a0a5c7874ba2b1257/packages/markdown-exit/src/parser/inline/rules/html_inline.ts#L19-L55
-  md.inline.ruler.after("html_inline", "svelte_inline", (state) => {
+  md.inline.ruler.after("html_inline", "svelte_inline", (state, silent) => {
     if (!state.md.options.html) return false;
 
     const line = state.src.slice(state.pos, state.posMax);
@@ -81,10 +87,12 @@ export default function plugin(md: MarkdownExit): void {
 
     if (!match) return false;
 
-    state.pos += match[0].length;
-    const token = state.push("html_inline", "", 0);
-    token.content = line.slice(0, match[0].length);
+    if (!silent) {
+      const token = state.push("html_inline", "", 0);
+      token.content = line.slice(0, match[0].length);
+    }
 
+    state.pos += match[0].length;
     return true;
   });
 }

--- a/src/markdown-it-svelte-components/index.ts
+++ b/src/markdown-it-svelte-components/index.ts
@@ -1,7 +1,6 @@
 import type { MarkdownExit } from "markdown-exit";
 
-// Adapted from
-// https://github.com/sveltejs/svelte/blob/3dbd95075c324304d668d72e0c08ed958173fb8f/packages/svelte/src/compiler/phases/1-parse/state/element.js#L39-L42
+// Adapted from https://github.com/sveltejs/svelte/blob/3dbd95075c324304d668d72e0c08ed958173fb8f/packages/svelte/src/compiler/phases/1-parse/state/element.js#L39-L42
 // and https://github.com/serkodev/markdown-exit/blob/fe1351070a5841426223ab4a0a5c7874ba2b1257/packages/markdown-exit/src/parser/block/rules/html_block.ts#L16
 const SVELTE_COMPONENT_BLOCK_RE =
   /^<\/?(?:\p{Lu}[\p{ID_Continue}$.\u200c\u200d]*|\p{ID_Start}[\p{ID_Continue}$\u200c\u200d]*(?:\.[\p{ID_Continue}$\u200c\u200d]+)+)(?=\s|\/?>|$)/u;
@@ -9,44 +8,59 @@ const SVELTE_COMPONENT_INLINE_RE =
   /^<\/?(?:\p{Lu}|\p{ID_Start}[\p{ID_Continue}$\u200c\u200d]*\.[\p{ID_Continue}$\u200c\u200d])[^>]+>/u;
 
 /**
- * Parse Svelte components as html_block and html_inline tokens
+ * Markdown-exit plugin to extend the HTML CommonMark specification to recognize Svelte components as HTML tags, both for block and inline parsing.
  */
 export default function plugin(md: MarkdownExit): void {
-  // Find lines starting with `<Something` and apply the same logic as for https://spec.commonmark.org/0.30/#html-blocks, #6
-  // Adapted from https://github.com/serkodev/markdown-exit/blob/fe1351070a5841426223ab4a0a5c7874ba2b1257/packages/markdown-exit/src/parser/block/rules/html_block.ts#L20-L77
+  /**
+   * Adapted from https://github.com/serkodev/markdown-exit/blob/fe1351070a5841426223ab4a0a5c7874ba2b1257/packages/markdown-exit/src/parser/block/rules/html_block.ts#L20-L77
+   *
+   * Implement the following [CommonMark HTML blocks specification](https://spec.commonmark.org/0.30/#html-blocks) extension:
+   *
+   * 6. Start condition: line begins the string `<` or `</` followed by one of the strings (case-insensitive) `address`, ..., `ul` **or a valid Svelte component name** followed by a space, a tab, the end of the line, the string `>`, or the string `/>`.
+   *    End condition: line is followed by a blank line.
+   *
+   * The beginning of the rule is already implemented by the original `html_block` rule.
+   */
   md.block.ruler.after(
     "html_block",
-    "svelte_tag",
+    "svelte_block",
     (state, startLine, endLine) => {
+      // No need to run the rule if HTML is not enabled
       if (!state.md.options.html) return false;
 
+      // Retrieve the current Markdown line
       const lineText = state.src.slice(
         state.bMarks[startLine] + state.tShift[startLine],
         state.eMarks[startLine],
       );
 
+      // Check if the line starts with `<` or `</` followed by a valid Svelte component name
+      // followed by a space, the end of the line, the string `>`, or the string `/>`
       if (!SVELTE_COMPONENT_BLOCK_RE.test(lineText)) return false;
 
-      // We found `<Something` starting a line, let's find a `>` that ends a line
-      let nextLine = startLine + 1;
+      // "End condition: line is followed by a blank line."
+      // Let's find the next blank line
+      state.line++;
 
-      while (nextLine < endLine && state.sCount[nextLine] >= state.blkIndent) {
-        const nextLineText = state.src.slice(
-          state.bMarks[nextLine] + state.tShift[nextLine],
-          state.eMarks[nextLine],
-        );
-        if (nextLineText === "") break;
-        nextLine++; // Make `nextLine` always point to the next line
+      while (
+        // Break at the end of the document
+        state.line < endLine &&
+        // Break if the line is under-intended, it means that a list item or a blockquote ended and the HTML block should end as well
+        state.sCount[state.line] >= state.blkIndent &&
+        // Break if the line is blank
+        state.src.slice(
+          state.bMarks[state.line] + state.tShift[state.line],
+          state.eMarks[state.line],
+        ) !== ""
+      ) {
+        state.line++;
       }
 
-      // Update the line pointer
-      state.line = nextLine;
-
       const token = state.push("html_block", "", 0);
-      token.map = [startLine, nextLine];
+      token.map = [startLine, state.line];
       token.content = state.getLines(
         startLine,
-        nextLine,
+        state.line,
         state.blkIndent,
         true,
       );
@@ -55,12 +69,14 @@ export default function plugin(md: MarkdownExit): void {
     },
   );
 
-  // Implement https://spec.commonmark.org/0.30/#tag-name for Svelte components
+  // Extend https://spec.commonmark.org/0.30/#tag-name for Svelte components
   // Adapted from https://github.com/serkodev/markdown-exit/blob/fe1351070a5841426223ab4a0a5c7874ba2b1257/packages/markdown-exit/src/parser/inline/rules/html_inline.ts#L19-L55
-  md.inline.ruler.after("html_inline", "svelte_tag_inline", (state) => {
+  md.inline.ruler.after("html_inline", "svelte_inline", (state) => {
     if (!state.md.options.html) return false;
 
     const line = state.src.slice(state.pos, state.posMax);
+
+    // `<` or `</` followed by a valid Svelte component name until the next `>`
     const match = SVELTE_COMPONENT_INLINE_RE.exec(line);
 
     if (!match) return false;

--- a/src/markdown-it-svelte-components/index.ts
+++ b/src/markdown-it-svelte-components/index.ts
@@ -5,7 +5,7 @@ import type { MarkdownExit } from "markdown-exit";
 const SVELTE_COMPONENT_BLOCK_RE =
   /^<\/?(?:\p{Lu}[\p{ID_Continue}$.\u200c\u200d]*|\p{ID_Start}[\p{ID_Continue}$\u200c\u200d]*(?:\.[\p{ID_Continue}$\u200c\u200d]+)+)(?=\s|\/?>|$)/u;
 const SVELTE_COMPONENT_INLINE_RE =
-  /^<\/?(?:\p{Lu}|\p{ID_Start}[\p{ID_Continue}$\u200c\u200d]*\.[\p{ID_Continue}$\u200c\u200d])[^>]+>/u;
+  /^<\/?(?:\p{Lu}[\p{ID_Continue}$.\u200c\u200d]*|\p{ID_Start}[\p{ID_Continue}$\u200c\u200d]*(?:\.[\p{ID_Continue}$\u200c\u200d]+)+)(?:\s[^>]*|\/?)>/u;
 
 /**
  * Markdown-exit plugin to extend the HTML CommonMark specification to recognize Svelte components as HTML tags, both for block and inline parsing.

--- a/src/markdown-it-svelte-components/index.ts
+++ b/src/markdown-it-svelte-components/index.ts
@@ -1,0 +1,72 @@
+import type { MarkdownExit } from "markdown-exit";
+
+// https://github.com/sveltejs/svelte/blob/3dbd95075c324304d668d72e0c08ed958173fb8f/packages/svelte/src/compiler/phases/1-parse/state/element.js#L39-L42
+const SVELTE_COMPONENT_RE =
+  /^<(?:\p{Lu}[\p{ID_Continue}$.\u200c\u200d]*|\p{ID_Start}[\p{ID_Continue}$\u200c\u200d]*(?:\.[\p{ID_Continue}$\u200c\u200d]+)+)/u;
+
+/**
+ * Parse Svelte components as html_block and html_inline tokens
+ */
+export default function plugin(md: MarkdownExit): void {
+  md.block.ruler.after(
+    "html_block",
+    "svelte_tag",
+    (state, startLine, endLine) => {
+      if (!state.md.options.html) return false;
+
+      const lineText = state.src.slice(
+        state.bMarks[startLine] + state.tShift[startLine],
+        state.eMarks[startLine],
+      );
+
+      if (!SVELTE_COMPONENT_RE.test(lineText)) return false;
+
+      // We found `<Something` starting a line, let's find a `>` that ends a line
+      let nextLine = startLine;
+
+      while (nextLine < endLine) {
+        const nextLineText = state.src.slice(
+          state.bMarks[nextLine] + state.tShift[nextLine],
+          state.eMarks[nextLine],
+        );
+        nextLine++; // Make `nextLine` always point to the next line
+        if (nextLineText.trimEnd().endsWith(">")) break;
+      }
+
+      // Update the line pointer
+      state.line = nextLine;
+
+      const token = state.push("html_block", "", 0);
+      token.map = [startLine, nextLine];
+      token.content = state.getLines(
+        startLine,
+        nextLine,
+        state.blkIndent,
+        true,
+      );
+
+      return true;
+    },
+  );
+
+  // Same logic as above, find `<Something` then `>` in inline text
+  md.inline.ruler.after("html_inline", "svelte_tag_inline", (state) => {
+    if (!state.md.options.html) return false;
+
+    const line = state.src.slice(state.pos, state.posMax);
+    const match = SVELTE_COMPONENT_RE.exec(line);
+
+    if (!match) return false;
+
+    const end = line.indexOf(">", match[0].length);
+
+    if (end === -1) return false;
+
+    state.pos += end + 1;
+
+    const token = state.push("html_inline", "", 0);
+    token.content = line.slice(match.index, end + 1);
+
+    return true;
+  });
+}

--- a/src/markdown-it-svelte-components/index.ts
+++ b/src/markdown-it-svelte-components/index.ts
@@ -43,21 +43,19 @@ export default function plugin(md: MarkdownExit): void {
 
       // "End condition: line is followed by a blank line."
       // Let's find the next blank line
-      state.line++;
-
-      while (
+      do {
+        state.line++;
+      } while (
         // Break at the end of the document
         state.line < endLine &&
-        // Break if the line is under-intended, it means that a list item or a blockquote ended and the HTML block should end as well
+        // Break if the line is under-intended, meaning that a list item ended and the HTML block should end as well
         state.sCount[state.line] >= state.blkIndent &&
         // Break if the line is blank
         state.src.slice(
           state.bMarks[state.line] + state.tShift[state.line],
           state.eMarks[state.line],
         ) !== ""
-      ) {
-        state.line++;
-      }
+      );
 
       const token = state.push("html_block", "", 0);
       token.map = [startLine, state.line];

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,6 +1,7 @@
 import * as devalue from "devalue";
 import { createMarkdownExit } from "markdown-exit";
 import * as yaml from "yaml";
+import markdownItSvelteComponents from "./markdown-it-svelte-components/index.ts";
 import markdownItSvelteTags from "./markdown-it-svelte-tags/index.ts";
 import markdownItSvelteCurlyBracesEscape from "./markdown-it-svelte-curly-braces-escape/index.ts";
 import { toArray } from "./utils.ts";
@@ -123,7 +124,10 @@ export function createMarkdownProcessor(
     }
     return !IS_SVELTE_TAG_NAME_RE.test(url);
   };
-  markdownIt.use(markdownItSvelteTags).use(markdownItSvelteCurlyBracesEscape);
+  markdownIt
+    .use(markdownItSvelteTags)
+    .use(markdownItSvelteCurlyBracesEscape)
+    .use(markdownItSvelteComponents);
 
   options.use?.(markdownIt);
   options.markdownItUses.forEach((e) => {

--- a/tests/unit/__snapshots__/transform.test.ts.snap
+++ b/tests/unit/__snapshots__/transform.test.ts.snap
@@ -104,6 +104,51 @@ export const frontmatter = {};
 </div>"
 `;
 
+exports[`transform > parses Svelte components as HTML 1`] = `
+"<script context="module">
+export const frontmatter = {};
+</script>
+
+
+<div class="markdown-body"><p>Basic</p>
+<Component foo="foo" bar={"bar"} />
+<p>Multi-line</p>
+<Component
+  foo="foo"
+  bar={"bar"}
+/>
+<p>With children</p>
+<Component foo="foo" bar={"bar"}>
+<p>I’m <strong>not</strong> markdown
+</Component></p>
+<p>With markdown children</p>
+<Component foo="foo" bar={"bar"}>
+<h1>Heading</h1>
+<p>I’m <strong>markdown</strong> inside a component</p>
+</Component>
+<p>Works in lists too</p>
+<ul>
+<li>
+<Component
+  foo="foo"
+  bar={"bar"}
+/>
+</li>
+</ul>
+<p>Does not break indent-based code blocks</p>
+<pre><code>&lt;Component
+  foo=&quot;foo&quot;
+  bar=&#123;&quot;bar&quot;&#125;
+/&gt;
+</code></pre>
+<p>Inline component <Comp foo="foo" bar={"bar"} /> also works</p>
+<p>Even multiline <Comp
+  foo="foo"
+  bar={"bar"}
+/> works</p>
+</div>"
+`;
+
 exports[`transform > script 1`] = `
 "<script context="module">
 export const frontmatter = {};

--- a/tests/unit/__snapshots__/transform.test.ts.snap
+++ b/tests/unit/__snapshots__/transform.test.ts.snap
@@ -149,6 +149,9 @@ export const frontmatter = {};
 <p>A component will close the current paragraph</p>
 <Component />
 <p>This one is invalid an will be &lt;/Ignored/&gt;</p>
+<p>Example 616</p>
+<p><a foo="bar" bam = 'baz <em>"</em>'
+_boolean zoop:33=zoop:33 /></p>
 </div>"
 `;
 

--- a/tests/unit/__snapshots__/transform.test.ts.snap
+++ b/tests/unit/__snapshots__/transform.test.ts.snap
@@ -207,6 +207,5 @@ export const frontmatter = {title:"Markdown to Svelte"};
 <li>List</li>
 </ul>
 
-<p><MyComponent>You can use Svelte components in Markdown</MyComponent></p>
-</div>"
+<MyComponent>You can use Svelte components in Markdown</MyComponent></div>"
 `;

--- a/tests/unit/__snapshots__/transform.test.ts.snap
+++ b/tests/unit/__snapshots__/transform.test.ts.snap
@@ -146,7 +146,8 @@ export const frontmatter = {};
   foo="foo"
   bar={"bar"}
 /> works</p>
-</div>"
+<p>A component will close the current paragraph</p>
+<Component /></div>"
 `;
 
 exports[`transform > script 1`] = `

--- a/tests/unit/__snapshots__/transform.test.ts.snap
+++ b/tests/unit/__snapshots__/transform.test.ts.snap
@@ -119,8 +119,8 @@ export const frontmatter = {};
 />
 <p>With children</p>
 <Component foo="foo" bar={"bar"}>
-<p>I’m <strong>not</strong> markdown
-</Component></p>
+  I'm **not** markdown
+</Component>
 <p>With markdown children</p>
 <Component foo="foo" bar={"bar"}>
 <h1>Heading</h1>

--- a/tests/unit/__snapshots__/transform.test.ts.snap
+++ b/tests/unit/__snapshots__/transform.test.ts.snap
@@ -147,7 +147,9 @@ export const frontmatter = {};
   bar={"bar"}
 /> works</p>
 <p>A component will close the current paragraph</p>
-<Component /></div>"
+<Component />
+<p>This one is invalid an will be &lt;/Ignored/&gt;</p>
+</div>"
 `;
 
 exports[`transform > script 1`] = `

--- a/tests/unit/transform.test.ts
+++ b/tests/unit/transform.test.ts
@@ -182,6 +182,9 @@ Even multiline <Comp
   foo="foo"
   bar={"bar"}
 /> works
+
+A component will close the current paragraph
+<Component />
 `;
     expect(await mdToSvelte("", md)).toMatchSnapshot();
   });

--- a/tests/unit/transform.test.ts
+++ b/tests/unit/transform.test.ts
@@ -187,6 +187,11 @@ A component will close the current paragraph
 <Component />
 
 This one is invalid an will be </Ignored/>
+
+Example 616
+
+<a foo="bar" bam = 'baz <em>"</em>'
+_boolean zoop:33=zoop:33 />
 `;
     expect(await mdToSvelte("", md)).toMatchSnapshot();
   });

--- a/tests/unit/transform.test.ts
+++ b/tests/unit/transform.test.ts
@@ -185,6 +185,8 @@ Even multiline <Comp
 
 A component will close the current paragraph
 <Component />
+
+This one is invalid an will be </Ignored/>
 `;
     expect(await mdToSvelte("", md)).toMatchSnapshot();
   });

--- a/tests/unit/transform.test.ts
+++ b/tests/unit/transform.test.ts
@@ -133,4 +133,56 @@ title: "\`{#if}\`"
 `;
     expect(await mdToSvelte("", md)).toMatchSnapshot();
   });
+
+  it.only("parses Svelte components as HTML", async () => {
+    const md = `Basic
+
+<Component foo="foo" bar={"bar"} />
+
+Multi-line
+
+<Component
+  foo="foo"
+  bar={"bar"}
+/>
+
+With children
+
+<Component foo="foo" bar={"bar"}>
+  I'm **not** markdown
+</Component>
+
+With markdown children
+
+<Component foo="foo" bar={"bar"}>
+
+# Heading
+
+I'm **markdown** inside a component
+
+</Component>
+
+Works in lists too
+
+- <Component
+    foo="foo"
+    bar={"bar"}
+  />
+
+Does not break indent-based code blocks
+
+    <Component
+      foo="foo"
+      bar={"bar"}
+    />
+
+Inline component <Comp foo="foo" bar={"bar"} /> also works
+
+Even multiline <Comp
+  foo="foo"
+  bar={"bar"}
+/> works
+`;
+    expect(await mdToSvelte("", md)).toMatchSnapshot();
+  });
 });

--- a/tests/unit/transform.test.ts
+++ b/tests/unit/transform.test.ts
@@ -134,7 +134,7 @@ title: "\`{#if}\`"
     expect(await mdToSvelte("", md)).toMatchSnapshot();
   });
 
-  it.only("parses Svelte components as HTML", async () => {
+  it("parses Svelte components as HTML", async () => {
     const md = `Basic
 
 <Component foo="foo" bar={"bar"} />


### PR DESCRIPTION
Hi!

My attempt at fixing #138 

It works by parsing things that look like Svelte components as HTML (support both block and inline HTML)

You might want to install https://pkg.pr.new/ so that @sacrosanctic can test and report if it works for their use cases

Cheers!