### PR TITLE
feat: support standalone `@sveltejs/enhanced-img` tags in markdown

### DIFF
--- a/.changeset/quiet-enhanced-images.md
+++ b/.changeset/quiet-enhanced-images.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-svelte-md": minor
+---
+
+Support standalone `@sveltejs/enhanced-img` tags in Markdown.

--- a/src/markdown-it-svelte-tags/index.ts
+++ b/src/markdown-it-svelte-tags/index.ts
@@ -1,6 +1,15 @@
 import type { MarkdownExit } from "markdown-exit";
 
-const SVELTE_TAGS_RE = /^(?:<svelte:[a-z][^>]*>|<\/svelte:[a-z]+>)/u;
+export const TAG_NAME_RE = /(?:svelte:[a-z]+|enhanced:img)/u;
+const OPEN_TAG_RE = new RegExp(
+  String.raw`<${TAG_NAME_RE.source}(?:\s[^>]*)?/?>`,
+  "u",
+);
+const CLOSE_TAG_RE = new RegExp(String.raw`</${TAG_NAME_RE.source}\s*>`, "u");
+const SVELTE_TAGS_RE = new RegExp(
+  `^(?:${OPEN_TAG_RE.source}|${CLOSE_TAG_RE.source})`,
+  "u",
+);
 /**
  * Svelte tags (e.g. `<svelte:head>`) plugin
  */

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,7 +1,9 @@
 import * as devalue from "devalue";
 import { createMarkdownExit } from "markdown-exit";
 import * as yaml from "yaml";
-import markdownItSvelteTags from "./markdown-it-svelte-tags/index.ts";
+import markdownItSvelteTags, {
+  TAG_NAME_RE,
+} from "./markdown-it-svelte-tags/index.ts";
 import markdownItSvelteCurlyBracesEscape from "./markdown-it-svelte-curly-braces-escape/index.ts";
 import { toArray } from "./utils.ts";
 import { headObjToTags, preprocessHead } from "./head.ts";
@@ -11,7 +13,7 @@ const SCRIPTS_RE = /(<script[^>]*>)([\s\S]*?)<\/script>/gu;
 const SVELTE_TAGS_RE = /(<svelte:[a-z][^>]*>)([\s\S]*?)<\/svelte:[a-z]+>/gu;
 const GET_SVELTE_TAG_NAME_RE = /^svelte:[a-z]+/u;
 const IS_MODULE_CONTEXT_RE = /\bcontext\s*=\s*["']?module["']?|\bmodule\b/u;
-const IS_SVELTE_TAG_NAME_RE = /^svelte:[a-z]+$/u;
+const IS_SVELTE_TAG_NAME_RE = new RegExp(`^${TAG_NAME_RE.source}/?$`, "u");
 const FRONTMATTER_RE =
   /^---(?:\r?\n|\r)(?:([\s\S]*?)(?:\r?\n|\r))?---(?:\r?\n|\r|$)/;
 

--- a/tests/unit/__snapshots__/transform.test.ts.snap
+++ b/tests/unit/__snapshots__/transform.test.ts.snap
@@ -165,3 +165,19 @@ export const frontmatter = {title:"Markdown to Svelte"};
 <p><MyComponent>You can use Svelte components in Markdown</MyComponent></p>
 </div>"
 `;
+
+exports[`transform > use enhanced image tag 1`] = `
+"<script module>
+export const frontmatter = {};
+</script>
+<script>
+
+    import TestImage from './test.png?enhanced'
+
+</script>
+
+<div class="markdown-body">
+<p><enhanced:img src={TestImage} alt="some alt text" />
+<enhanced:img src={TestImage} alt="compact"/></p>
+</div>"
+`;

--- a/tests/unit/transform.test.ts
+++ b/tests/unit/transform.test.ts
@@ -102,6 +102,42 @@ title: Markdown to Svelte
 `;
     expect(await mdToSvelte("", md)).toMatchSnapshot();
   });
+  it("use enhanced image tag", async () => {
+    const md = `
+<script>
+    import TestImage from './test.png?enhanced'
+</script>
+<enhanced:img src={TestImage} alt="some alt text" />
+<enhanced:img src={TestImage} alt="compact"/>
+`;
+    expect(await mdToSvelte("", md)).toMatchSnapshot();
+  });
+  it("does not autolink enhanced image tag without attributes", async () => {
+    const md = `
+<enhanced:img></enhanced:img>
+`;
+    expect(await mdToSvelte("", md)).toContain(
+      "<p><enhanced:img></enhanced:img></p>",
+    );
+  });
+  it("does not autolink self-closing enhanced image tag without attributes", async () => {
+    const md = `
+<enhanced:img/>
+`;
+    expect(await mdToSvelte("", md)).toContain("<p><enhanced:img/></p>");
+  });
+  it("does not parse enhanced image tag name prefixes", async () => {
+    const md = `
+<enhanced:imgfoo alt="x" />
+<enhanced:img-foo alt="x" />
+`;
+    const svelte = await mdToSvelte("", md);
+
+    expect(svelte).toContain("&lt;enhanced:imgfoo");
+    expect(svelte).toContain("&lt;enhanced:img-foo");
+    expect(svelte).not.toContain("<enhanced:imgfoo");
+    expect(svelte).not.toContain("<enhanced:img-foo");
+  });
   it("escape curly braces in fence", async () => {
     const md = `
 \`\`\`js


### PR DESCRIPTION
close #149